### PR TITLE
Load request body before making connection to the real server

### DIFF
--- a/examples/preventRequest.ts
+++ b/examples/preventRequest.ts
@@ -10,9 +10,21 @@ proxy.onError((ctx, err, errorKind) => {
   console.error(`${errorKind} on ${url}:`, err);
 });
 
-proxy.onRequest((ctx, callback) => {
-  ctx.proxyToClientResponse.end("Hacked, you cannot proceed to the website");
-  // no callback() so proxy request is not sent to the server
+proxy.onRequest((ctx, callbackOnRequest) => {
+  let requestBodyBuffer: Buffer[] = [];
+
+  proxy.onRequestData(function (ctx, chunk, callback) {
+    requestBodyBuffer.push(chunk);
+    callback(null, chunk);
+  });
+
+  proxy.onRequestEnd(function (ctx, callback) {
+    const rawBody = Buffer.concat(requestBodyBuffer);
+
+    console.log("Request body before event onRequest has triggered: ", rawBody);
+
+    callbackOnRequest();
+  });
 });
 
 proxy.listen({ port });

--- a/examples/preventRequest.ts
+++ b/examples/preventRequest.ts
@@ -10,21 +10,9 @@ proxy.onError((ctx, err, errorKind) => {
   console.error(`${errorKind} on ${url}:`, err);
 });
 
-proxy.onRequest((ctx, callbackOnRequest) => {
-  let requestBodyBuffer: Buffer[] = [];
-
-  proxy.onRequestData(function (ctx, chunk, callback) {
-    requestBodyBuffer.push(chunk);
-    callback(null, chunk);
-  });
-
-  proxy.onRequestEnd(function (ctx, callback) {
-    const rawBody = Buffer.concat(requestBodyBuffer);
-
-    console.log("Request body before event onRequest has triggered: ", rawBody);
-
-    callbackOnRequest();
-  });
+proxy.onRequest((ctx, callback) => {
+  ctx.proxyToClientResponse.end("Hacked, you cannot proceed to the website");
+  // no callback() so proxy request is not sent to the server
 });
 
 proxy.listen({ port });

--- a/lib/ClientFinalRequestFilter.ts
+++ b/lib/ClientFinalRequestFilter.ts
@@ -1,0 +1,49 @@
+import events from "events";
+
+export class ClientFinalRequestFilter extends events.EventEmitter {
+  public writable: boolean;
+  public write: (chunk: Buffer) => void;
+  public end: (chunk: Buffer) => void;
+
+  constructor(proxy, ctx) {
+    super();
+    this.writable = true;
+    this.write = (chunk) => {
+      proxy._onRequestData(ctx, chunk, (err, chunk) => {
+        if (err) {
+          return proxy._onError("ON_REQUEST_DATA_ERROR", ctx, err);
+        }
+        if (chunk) {
+          // Save the chunk so we can use it later
+          ctx.requestBodyBuffer.push(chunk);
+        }
+      });
+      return true;
+    };
+
+    this.end = (chunk) => {
+      if (chunk) {
+        // Save the chunk so we can use it later
+        ctx.requestBodyBuffer.push(chunk);
+
+        return proxy._onRequestData(ctx, chunk, (err, chunk) => {
+          if (err) {
+            return proxy._onError("ON_REQUEST_DATA_ERROR", ctx, err);
+          }
+
+          return proxy._onRequestEnd(ctx, (err) => {
+            if (err) {
+              return proxy._onError("ON_REQUEST_END_ERROR", ctx, err);
+            }
+          });
+        });
+      } else {
+        return proxy._onRequestEnd(ctx, (err) => {
+          if (err) {
+            return proxy._onError("ON_REQUEST_END_ERROR", ctx, err);
+          }
+        });
+      }
+    };
+  }
+}

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1150,9 +1150,8 @@ export class Proxy implements IProxy {
         agent: ctx.isSSL ? self.httpsAgent : self.httpAgent,
       };
 
-      // Before making the connection between the proxy server and the real server
-      // We emit the request body first, so the user can use this before invoking
-      // the function callBack in event onRequest.
+      // Before making the connection between the proxy server and the real server.
+      // We emit the request body first, so the user can use this before the `onRequest` event is triggered.
       ctx.requestFilters.push(new ClientFinalRequestFilter(self, ctx));
       var prevRequestPipeElem = ctx.clientToProxyRequest;
       ctx.requestFilters.forEach(function (filter) {
@@ -1162,6 +1161,9 @@ export class Proxy implements IProxy {
         );
         prevRequestPipeElem = prevRequestPipeElem.pipe(filter);
       });
+
+      // Removing the ClientFinalRequestFilter object to prevent potential bugs after the work has done.
+      ctx.requestFilters.pop();
 
       return self._onRequest(ctx, (err) => {
         if (err) {

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1150,8 +1150,8 @@ export class Proxy implements IProxy {
         agent: ctx.isSSL ? self.httpsAgent : self.httpAgent,
       };
 
-      // Before making the connection between the proxy server and the real server.
-      // We emit the request body first, so the user can use this before the `onRequest` event is triggered.
+      // Before making the connection between the proxy server and the real server,
+      // we emit the request body first, so the user can use this before the `onRequest` event is triggered.
       ctx.requestFilters.push(new ClientFinalRequestFilter(self, ctx));
       var prevRequestPipeElem = ctx.clientToProxyRequest;
       ctx.requestFilters.forEach(function (filter) {

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -19,7 +19,6 @@ import url from "url";
 import semaphore from "semaphore";
 import ca from "./ca";
 import { ProxyFinalResponseFilter } from "./ProxyFinalResponseFilter";
-import { ProxyFinalRequestFilter } from "./ProxyFinalRequestFilter";
 import { v4 as uuid } from "uuid";
 
 import gunzip from "./middleware/gunzip";
@@ -49,6 +48,7 @@ import type {
   OnRequestDataCallback,
 } from "./types";
 import type stream from "node:stream";
+import { ClientFinalRequestFilter } from "./ClientFinalRequestFilter";
 export { wildcard, gunzip };
 
 type HandlerType<T extends (...args: any[]) => any> = Array<Parameters<T>[0]>;
@@ -955,6 +955,7 @@ export class Proxy implements IProxy {
       onResponseEndHandlers: [],
       requestFilters: [],
       responseFilters: [],
+      requestBodyBuffer: [],
       responseContentPotentiallyModified: false,
       onRequest(fn) {
         ctx.onRequestHandlers.push(fn);
@@ -1096,19 +1097,29 @@ export class Proxy implements IProxy {
         ctx.proxyToServerRequestOptions!,
         proxyToServerRequestComplete
       );
+
       ctx.proxyToServerRequest.on(
         "error",
         self._onError.bind(self, "PROXY_TO_SERVER_REQUEST_ERROR", ctx)
       );
-      ctx.requestFilters.push(new ProxyFinalRequestFilter(self, ctx));
-      let prevRequestPipeElem = ctx.clientToProxyRequest;
-      ctx.requestFilters.forEach((filter) => {
-        filter.on(
-          "error",
-          self._onError.bind(self, "REQUEST_FILTER_ERROR", ctx)
-        );
-        prevRequestPipeElem = prevRequestPipeElem.pipe(filter);
-      });
+
+      // After the connection has completed, we process the request body
+      // from the proxy server to the real server
+      if (ctx.requestBodyBuffer.length === 0) {
+        ctx.proxyToServerRequest.end(undefined);
+      } else {
+        for (let i = 0; i < ctx.requestBodyBuffer.length; i++) {
+          if (i === ctx.requestBodyBuffer.length - 1) {
+            ctx.proxyToServerRequest.end(ctx.requestBodyBuffer[i]);
+          } else {
+            ctx.proxyToServerRequest.write(ctx.requestBodyBuffer[i]);
+          }
+        }
+      }
+
+      // Releasing the request data
+      // and resuming the request stream from client to proxy server.
+      ctx.requestBodyBuffer = [];
       ctx.clientToProxyRequest.resume();
     }
 
@@ -1138,6 +1149,20 @@ export class Proxy implements IProxy {
         headers,
         agent: ctx.isSSL ? self.httpsAgent : self.httpAgent,
       };
+
+      // Before making the connection between the proxy server and the real server
+      // We emit the request body first, so the user can use this before invoking
+      // the function callBack in event onRequest.
+      ctx.requestFilters.push(new ClientFinalRequestFilter(self, ctx));
+      var prevRequestPipeElem = ctx.clientToProxyRequest;
+      ctx.requestFilters.forEach(function (filter) {
+        filter.on(
+          "error",
+          self._onError.bind(self, "LOAD_REQUEST_BODY_ERROR", ctx)
+        );
+        prevRequestPipeElem = prevRequestPipeElem.pipe(filter);
+      });
+
       return self._onRequest(ctx, (err) => {
         if (err) {
           return self._onError("ON_REQUEST_ERROR", ctx, err);
@@ -1207,7 +1232,7 @@ export class Proxy implements IProxy {
         if (destWebSocket.readyState === WebSocket.OPEN) {
           switch (type) {
             case "message":
-              destWebSocket.send(data, {binary: flags as boolean});
+              destWebSocket.send(data, { binary: flags as boolean });
               break;
             case "ping":
               destWebSocket.ping(data, flags as boolean);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -294,7 +294,7 @@ export type IContext = ICallbacks &
     /** filters added by .addResponseFilter() */
     responseFilters: any[];
 
-    /** contains the chunk of request body */
+    /** contains the request body */
     requestBodyBuffer: Buffer[];
 
     /** undocumented, allows adjusting the request in callbacks (such as .onRequest()) before sending  upstream (to proxy or target host)..

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -103,7 +103,10 @@ export type OnCertificateRequiredCallback = (
   error: MaybeError,
   certDetails: ICertDetails
 ) => void;
-export type OnRequestDataCallback = (error?: MaybeError, chunk?: Buffer) => void;
+export type OnRequestDataCallback = (
+  error?: MaybeError,
+  chunk?: Buffer
+) => void;
 export type OnRequestDataParams = (
   ctx: IContext,
   chunk: Buffer,
@@ -291,22 +294,25 @@ export type IContext = ICallbacks &
     /** filters added by .addResponseFilter() */
     responseFilters: any[];
 
+    /** contains the chunk of request body */
+    requestBodyBuffer: Buffer[];
+
     /** undocumented, allows adjusting the request in callbacks (such as .onRequest()) before sending  upstream (to proxy or target host)..
      * FYI these values seem pre-populated with defaults based on the request, you can modify them to change behavior. */
     proxyToServerRequestOptions:
-    | undefined
-    | {
-      /** ex: "GET" */
-      method: string;
-      /** ex: "/success.txt" */
-      path: string;
+      | undefined
+      | {
+          /** ex: "GET" */
+          method: string;
+          /** ex: "/success.txt" */
+          path: string;
 
-      /** example: "detectportal.firefox.com" */
-      host: string;
-      port: string | number | null | undefined;
-      headers: { [key: string]: string };
-      agent: http.Agent;
-    };
+          /** example: "detectportal.firefox.com" */
+          host: string;
+          port: string | number | null | undefined;
+          headers: { [key: string]: string };
+          agent: http.Agent;
+        };
 
     onRequestHandlers: OnRequestParams[];
     onResponseHandlers: OnRequestParams[];


### PR DESCRIPTION
### Description
 - Change logic to load the full request body before making the connection between the proxy server and the real server

### Why we need this
 - In some cases, the users want to inspect the request body before making any connection to the real server.
 - So if the request body doesn't meet their condition, the users may want to prevent the request from being processed.
 - With the  [current implementation of the library](https://github.com/joeferner/node-http-mitm-proxy/tree/310a3bc8918b07b9c7dbdb345e358f8be2a74044) we can only get the request body after the `onRequest` event is triggered, which occurs after the connection has already been made to the real server.

### How to test
```ts
proxy.onRequest((ctx, callbackOnRequest) => {
  let requestBodyBuffer: Buffer[] = [];

  proxy.onRequestData(function (ctx, chunk, callback) {
    requestBodyBuffer.push(chunk);
    callback(null, chunk);
  });

  proxy.onRequestEnd(function (ctx, callback) {
    const rawBody = Buffer.concat(requestBodyBuffer);

    console.log("Request body before event onRequest has triggered: ", rawBody);

    callbackOnRequest();
  });
});
```